### PR TITLE
Fix tests for python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ executors:
       - image: docker:17.05.0-ce
   python_test:
     docker:
-      - image: cimg/python:3.9
+      - image: python:3.9-bullseye
   pre_commit_test:
     docker:
-      - image: cimg/python:3.9
+      - image: python:3.9-bullseye
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run: pip install pre-commit==1.18.3
+      - run: pip install pre-commit==2.12.1
       - run:
           name: Run pre-commit tests
           command: pre-commit run --all-files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ executors:
       - image: docker:17.05.0-ce
   python_test:
     docker:
-      - image: circleci/python:3.9-stretch
+      - image: cimg/python:3.9
   pre_commit_test:
     docker:
-      - image: circleci/python:3.9-stretch
+      - image: cimg/python:3.9
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ executors:
       - image: docker:17.05.0-ce
   python_test:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.9-stretch
   pre_commit_test:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.9-stretch
 
 jobs:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run: sudo pip install pre-commit==2.12.1
+      - run: pip install pre-commit==2.12.1
       - run: pre-commit install-hooks
 
       - save_cache:
@@ -63,7 +63,7 @@ jobs:
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run: sudo pip install pre-commit==1.18.3
+      - run: pip install pre-commit==1.18.3
       - run:
           name: Run pre-commit tests
           command: pre-commit run --all-files
@@ -76,8 +76,8 @@ jobs:
       - restore_cache:
           keys:
             - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
-      - run: sudo pip install -r requirements.txt
-      - run: sudo pip install -r requirements-dev.txt
+      - run: pip install -r requirements.txt
+      - run: pip install -r requirements-dev.txt
       - run: nosetests
 
 workflows:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 
   - repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 23.7.0
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.9
         exclude: >
           (?x)^(
             scripts/gen-docs-index|
           )$
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
       - id: check-ast
@@ -24,13 +24,13 @@ repos:
       - id: flake8
       - id: trailing-whitespace
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
+  - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.17.0
     hooks:
       - id: markdownlint
         entry: markdownlint --ignore .github/*.md
 
-  - repo: git://github.com/aws-cloudformation/cfn-python-lint
+  - repo: https://github.com/aws-cloudformation/cfn-python-lint
     rev: v0.49.0
     hooks:
       - id: cfn-python-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         entry: markdownlint --ignore .github/*.md
 
   - repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.49.0
+    rev: v0.79.7
     hooks:
       - id: cfn-python-lint
         files: deploy/

--- a/clamav_test.py
+++ b/clamav_test.py
@@ -156,7 +156,6 @@ class TestClamAV(unittest.TestCase):
             self.assertEquals(expected_md5_hash, md5_hash)
 
     def test_time_from_s3(self):
-
         expected_s3_time = datetime.datetime(2019, 1, 1)
 
         s3_stubber = Stubber(self.s3_client)

--- a/display_infected.py
+++ b/display_infected.py
@@ -30,7 +30,6 @@ from common import AV_STATUS_INFECTED
 
 # Get all objects in an S3 bucket that are infected
 def get_objects_and_sigs(s3_client, s3_bucket_name):
-
     s3_object_list = []
 
     s3_list_objects_result = {"IsTruncated": True}
@@ -76,7 +75,6 @@ def object_infected(s3_client, s3_bucket_name, key_name):
 
 
 def main(s3_bucket_name):
-
     # Verify the S3 bucket exists
     s3_client = boto3.client("s3", endpoint_url=S3_ENDPOINT)
     try:
@@ -87,7 +85,7 @@ def main(s3_bucket_name):
 
     # Scan the objects in the bucket
     s3_object_and_sigs_list = get_objects_and_sigs(s3_client, s3_bucket_name)
-    for (key_name, av_signature) in s3_object_and_sigs_list:
+    for key_name, av_signature in s3_object_and_sigs_list:
         print("Infected: {}/{}, {}".format(s3_bucket_name, key_name, av_signature))
 
 

--- a/display_infected_test.py
+++ b/display_infected_test.py
@@ -129,7 +129,6 @@ class TestDisplayInfected(unittest.TestCase):
             self.assertEqual(s3_object_list, expected_object_list)
 
     def test_get_objects_and_sigs_clean(self):
-
         get_object_tagging_response = {
             "VersionId": "abc123",
             "TagSet": [{"Key": AV_STATUS_METADATA, "Value": AV_STATUS_CLEAN}],
@@ -150,7 +149,6 @@ class TestDisplayInfected(unittest.TestCase):
             self.assertEqual(s3_object_list, expected_object_list)
 
     def test_get_objects_and_sigs_unscanned(self):
-
         get_object_tagging_response = {"VersionId": "abc123", "TagSet": []}
         get_object_tagging_expected_params = {
             "Bucket": self.s3_bucket_name,

--- a/scan.py
+++ b/scan.py
@@ -44,7 +44,6 @@ from common import get_timestamp
 
 
 def event_object(event, event_source="s3"):
-
     # SNS events are slightly different
     if event_source.upper() == "SNS":
         event = json.loads(event["Records"][0]["Sns"]["Message"])

--- a/scan_bucket.py
+++ b/scan_bucket.py
@@ -28,7 +28,6 @@ from common import S3_ENDPOINT
 
 # Get all objects in an S3 bucket that have not been previously scanned
 def get_objects(s3_client, s3_bucket_name):
-
     s3_object_list = []
 
     s3_list_objects_result = {"IsTruncated": True}
@@ -63,7 +62,6 @@ def object_previously_scanned(s3_client, s3_bucket_name, key_name):
 # Scan an S3 object for viruses by invoking the lambda function
 # Skip any objects that have already been scanned
 def scan_object(lambda_client, lambda_function_name, s3_bucket_name, key_name):
-
     print("Scanning: {}/{}".format(s3_bucket_name, key_name))
     s3_event = format_s3_event(s3_bucket_name, key_name)
     lambda_invoke_result = lambda_client.invoke(

--- a/scan_bucket_test.py
+++ b/scan_bucket_test.py
@@ -56,7 +56,6 @@ class TestDisplayInfected(unittest.TestCase):
         )
 
     def test_get_objects_previously_scanned_status(self):
-
         get_object_tagging_response = {
             "VersionId": "abc123",
             "TagSet": [{"Key": AV_STATUS_METADATA, "Value": AV_STATUS_INFECTED}],
@@ -77,7 +76,6 @@ class TestDisplayInfected(unittest.TestCase):
             self.assertEqual(s3_object_list, expected_object_list)
 
     def test_get_objects_previously_scanned_timestamp(self):
-
         get_object_tagging_response = {
             "VersionId": "abc123",
             "TagSet": [{"Key": AV_TIMESTAMP_METADATA, "Value": get_timestamp()}],
@@ -98,7 +96,6 @@ class TestDisplayInfected(unittest.TestCase):
             self.assertEqual(s3_object_list, expected_object_list)
 
     def test_get_objects_unscanned(self):
-
         get_object_tagging_response = {"VersionId": "abc123", "TagSet": []}
         get_object_tagging_expected_params = {
             "Bucket": self.s3_bucket_name,


### PR DESCRIPTION
We can use the existing test suite to verify changes going into future versions of python. Seems like an easy win.