### PR TITLE
Include ld command and various shared libraries in lambda bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/
 RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Copy shared libraries required for freshclams to run in lambda
-RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /opt/app/bin/
+RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/
 RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Copy shared libraries required for freshclams to run in lambda
-RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /opt/app/bin/
+RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,9 @@ RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/
 RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Copy shared libraries required for freshclams to run in lambda
-RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 /usr/lib64/libssl3.so /usr/lib64/libsmime3.so /opt/app/bin/
+RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 \
+/usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 \
+/usr/lib64/libssl3.so /usr/lib64/libsmime3.so /usr/lib64/libnss3.so /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN rpm2cpio nettle*.rpm | cpio -vimd
 
 
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /opt/app/bin/
+RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN rpm2cpio nettle*.rpm | cpio -vimd
 
 
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
+RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.* /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN rpm2cpio nettle*.rpm | cpio -vimd
 
 
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.* /opt/app/bin/
+RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,10 @@ RUN rpm2cpio nettle*.rpm | cpio -vimd
 
 # Copy over the binaries and libraries
 RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /opt/app/bin/
+RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Copy shared libraries required for freshclams to run in lambda
-RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /opt/app/bin/
+RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/
 RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Copy shared libraries required for freshclams to run in lambda
-RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 /usr/lib64/libssl3.so /opt/app/bin/
+RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 /usr/lib64/libssl3.so /usr/lib64/libsmime3.so /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 # Copy shared libraries required for freshclams to run in lambda
 RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 \
 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 \
-/usr/lib64/libssl3.so /usr/lib64/libsmime3.so /usr/lib64/libnss3.so /opt/app/bin/
+/usr/lib64/libssl3.so /usr/lib64/libsmime3.so /usr/lib64/libnss3.so /usr/lib64/libcrypt.so.1 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/
 RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Copy shared libraries required for freshclams to run in lambda
-RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /opt/app/bin/
+RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /opt/app/requirements.txt
 # Install packages
 RUN yum update -y
 RUN amazon-linux-extras install epel -y
-RUN yum install -y cpio yum-utils tar.x86_64 gzip zip python3-pip
+RUN yum install -y cpio yum-utils tar.x86_64 gzip zip python3-pip binutils
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
 RUN pip3 install -r requirements.txt
@@ -59,7 +59,7 @@ RUN rpm2cpio nettle*.rpm | cpio -vimd
 
 
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /opt/app/bin/
+RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/
 RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
 
 # Copy shared libraries required for freshclams to run in lambda
-RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 /opt/app/bin/
+RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 /usr/lib64/libssl3.so /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,10 @@ RUN rpm2cpio nettle*.rpm | cpio -vimd
 
 
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /opt/app/bin/
+RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /opt/app/bin/
+
+# Copy shared libraries required for freshclams to run in lambda
+RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 /opt/app/bin/
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf

--- a/clamav.py
+++ b/clamav.py
@@ -35,6 +35,7 @@ from common import AV_STATUS_INFECTED
 from common import CLAMAVLIB_PATH
 from common import CLAMSCAN_PATH
 from common import FRESHCLAM_PATH
+from common import LD_PATH
 from common import create_dir
 
 
@@ -42,7 +43,7 @@ RE_SEARCH_DIR = r"SEARCH_DIR\(\"=([A-z0-9\/\-_]*)\"\)"
 
 
 def current_library_search_path():
-    ld_verbose = subprocess.check_output(["ld", "--verbose"]).decode("utf-8")
+    ld_verbose = subprocess.check_output([LD_PATH, "--verbose"]).decode("utf-8")
     rd_ld = re.compile(RE_SEARCH_DIR)
     return rd_ld.findall(ld_verbose)
 

--- a/clamav.py
+++ b/clamav.py
@@ -43,7 +43,11 @@ RE_SEARCH_DIR = r"SEARCH_DIR\(\"=([A-z0-9\/\-_]*)\"\)"
 
 
 def current_library_search_path():
-    ld_verbose = subprocess.check_output([LD_PATH, "--verbose"]).decode("utf-8")
+    search_env = os.environ.copy()
+    search_env["LD_LIBRARY_PATH"] = CLAMAVLIB_PATH
+    ld_verbose = subprocess.check_output([LD_PATH, "--verbose"], env=search_env).decode(
+        "utf-8"
+    )
     rd_ld = re.compile(RE_SEARCH_DIR)
     return rd_ld.findall(ld_verbose)
 

--- a/common.py
+++ b/common.py
@@ -36,6 +36,7 @@ AV_TIMESTAMP_METADATA = os.getenv("AV_TIMESTAMP_METADATA", "av-timestamp")
 CLAMAVLIB_PATH = os.getenv("CLAMAVLIB_PATH", "./bin")
 CLAMSCAN_PATH = os.getenv("CLAMSCAN_PATH", "./bin/clamscan")
 FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
+LD_PATH = os.getenv("LD_PATH", "./bin/ld")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv(
     "AV_PROCESS_ORIGINAL_VERSION_ONLY", "False"
 )


### PR DESCRIPTION
Resolves #9 

Needed a lot of additional libraries copied in to run on the newer lambda runtimes.