### PR TITLE
Simplify Docker file. Use Amazon linux 2023. Test on Python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ executors:
       - image: docker:18.06.3-ce
   python_test:
     docker:
-      - image: python:3.11-bullseye
+      - image: python:3.12-bullseye
   pre_commit_test:
     docker:
-      - image: python:3.11-bullseye
+      - image: python:3.12-bullseye
 
 jobs:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM amazonlinux:2023
 
 # Set up working directories
 RUN mkdir -p /opt/app
@@ -9,75 +9,27 @@ RUN mkdir -p /opt/app/bin/
 WORKDIR /opt/app
 COPY ./*.py /opt/app/
 COPY requirements.txt /opt/app/requirements.txt
+COPY copylibs.sh /copylibs.sh
 
 # Install packages
 RUN yum update -y
-RUN amazon-linux-extras install epel -y
-RUN yum install -y cpio yum-utils tar.x86_64 gzip zip python3-pip binutils
+RUN yum install -y cpio clamav clamav-update yum-utils tar.x86_64 gzip zip python3.11 python3.11-pip binutils
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
-RUN pip3 install -r requirements.txt
+RUN pip3.11 install -r requirements.txt
 RUN rm -rf /root/.cache/pip
 
-# Download libraries we need to run in lambda
-WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav
-RUN rpm2cpio clamav-0*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav-lib
-RUN rpm2cpio clamav-lib*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav-update
-RUN rpm2cpio clamav-update*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 json-c
-RUN rpm2cpio json-c*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 pcre2
-RUN rpm2cpio pcre*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 libtool-ltdl
-RUN rpm2cpio libtool-ltdl*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 libxml2
-RUN rpm2cpio libxml2*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 bzip2-libs
-RUN rpm2cpio bzip2-libs*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 xz-libs
-RUN rpm2cpio xz-libs*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 libprelude
-RUN rpm2cpio libprelude*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 gnutls
-RUN rpm2cpio gnutls*.rpm | cpio -vimd
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 nettle
-RUN rpm2cpio nettle*.rpm | cpio -vimd
-
-
 # Copy over the binaries and libraries
-RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /usr/lib64/libpcre.so.1 /opt/app/bin/
-RUN cp /bin/ld /usr/lib64/libbfd-*.amzn2.so /opt/app/bin/
+RUN cp /bin/clamscan /usr/bin/freshclam /bin/ld /opt/app/bin/.
 
-# Copy shared libraries required for freshclams to run in lambda
-RUN cp /usr/lib64/libcurl.so.4 /usr/lib64/libnghttp2.so.14 /usr/lib64/libidn2.so.0 /usr/lib64/libssh2.so.1 \
-/usr/lib64/libldap-2.4.so.2 /usr/lib64/liblber-2.4.so.2 /usr/lib64/libunistring.so.0 /usr/lib64/libsasl2.so.3 \
-/usr/lib64/libssl3.so /usr/lib64/libsmime3.so /usr/lib64/libnss3.so /usr/lib64/libcrypt.so.1 /opt/app/bin/
+# Copy shared libraries required to run in lambda
+RUN bash /copylibs.sh
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf
 RUN echo "CompressLocalDatabase yes" >> /opt/app/bin/freshclam.conf
 RUN echo "ScriptedUpdates no" >> /opt/app/bin/freshclam.conf
 RUN echo "DatabaseDirectory /var/lib/clamav" >> /opt/app/bin/freshclam.conf
-
-RUN yum install shadow-utils.x86_64 -y
-
-RUN groupadd clamav
-RUN useradd -g clamav -s /bin/false -c "Clam Antivirus" clamav
-RUN useradd -g clamav -s /bin/false -c "Clam Antivirus" clamupdate
 
 ENV LD_LIBRARY_PATH=/opt/app/bin
 RUN ldconfig
@@ -86,7 +38,5 @@ RUN ldconfig
 WORKDIR /opt/app
 RUN zip -r9 --exclude="*test*" /opt/app/build/lambda.zip *.py bin
 
-WORKDIR /usr/local/lib/python3.7/site-packages
+WORKDIR /usr/local/lib/python3.11/site-packages
 RUN zip -r9 /opt/app/build/lambda.zip *
-
-WORKDIR /opt/app

--- a/clamav_test.py
+++ b/clamav_test.py
@@ -132,7 +132,7 @@ class TestClamAV(unittest.TestCase):
             md5_hash = md5_from_s3_tags(
                 self.s3_client, self.s3_bucket_name, self.s3_key_name
             )
-            self.assertEquals("", md5_hash)
+            self.assertEqual("", md5_hash)
 
     def test_md5_from_s3_tags_has_md5(self):
         expected_md5_hash = "d41d8cd98f00b204e9800998ecf8427e"
@@ -153,7 +153,7 @@ class TestClamAV(unittest.TestCase):
             md5_hash = md5_from_s3_tags(
                 self.s3_client, self.s3_bucket_name, self.s3_key_name
             )
-            self.assertEquals(expected_md5_hash, md5_hash)
+            self.assertEqual(expected_md5_hash, md5_hash)
 
     def test_time_from_s3(self):
         expected_s3_time = datetime.datetime(2019, 1, 1)
@@ -171,7 +171,7 @@ class TestClamAV(unittest.TestCase):
             s3_time = time_from_s3(
                 self.s3_client, self.s3_bucket_name, self.s3_key_name
             )
-            self.assertEquals(expected_s3_time, s3_time)
+            self.assertEqual(expected_s3_time, s3_time)
 
     @mock.patch("clamav.md5_from_file")
     @mock.patch("common.os.path.exists")
@@ -233,7 +233,7 @@ class TestClamAV(unittest.TestCase):
             to_download = update_defs_from_s3(
                 self.s3_client, self.s3_bucket_name, AV_DEFINITION_S3_PREFIX
             )
-            self.assertEquals(expected_to_download, to_download)
+            self.assertEqual(expected_to_download, to_download)
 
     @mock.patch("clamav.md5_from_file")
     @mock.patch("common.os.path.exists")
@@ -282,7 +282,7 @@ class TestClamAV(unittest.TestCase):
             to_download = update_defs_from_s3(
                 self.s3_client, self.s3_bucket_name, AV_DEFINITION_S3_PREFIX
             )
-            self.assertEquals(expected_to_download, to_download)
+            self.assertEqual(expected_to_download, to_download)
 
     @mock.patch("clamav.md5_from_file")
     @mock.patch("common.os.path.exists")
@@ -348,4 +348,4 @@ class TestClamAV(unittest.TestCase):
             to_download = update_defs_from_s3(
                 self.s3_client, self.s3_bucket_name, AV_DEFINITION_S3_PREFIX
             )
-            self.assertEquals(expected_to_download, to_download)
+            self.assertEqual(expected_to_download, to_download)

--- a/copylibs.sh
+++ b/copylibs.sh
@@ -1,7 +1,20 @@
 #/bin/bash
 set -e
 
-ldd /bin/clamscan /bin/freshclam /bin/ld | grep so | sed -e '/^[^\t]/ d' | sed -e 's/\t//' | sed -e 's/.*=..//' | sed -e 's/ (0.*)//' | sort | uniq | while read LIB;
+# We would expect the output from lld to be something like this
+# /bin/clamscan:
+#	  linux-vdso.so.1 (0x00007ffdf8967000)
+#	  libclamav.so.9 => /opt/app/bin/libclamav.so.9 (0x00007ff814aa9000)
+#	  libc.so.6 => /opt/app/bin/libc.so.6 (0x00007ff8148a1000)
+# We want to strip this down just the file paths so we can copy those over
+# 1. Removed things that don't have .so (ie they aren't libraries)
+# 2. Stripe whitespace
+# 3. Remove => and everything before it
+# 4. Remove the hexcodes in brackets
+# 5. Sort each line
+# 6. Remove duplicates
+# 7. Copy everything other than linux-vdso.so.1 into /opt/app/bin
+ldd /bin/clamscan /bin/freshclam /bin/ld | grep "\.so" | sed -e 's/\t//' | sed -e 's/.*=>.//' | sed -e 's/ (0.*)//' | sort | uniq | while read LIB;
 do
   case $LIB in
     "linux-vdso.so.1")

--- a/copylibs.sh
+++ b/copylibs.sh
@@ -6,6 +6,7 @@ do
   case $LIB in
     "linux-vdso.so.1")
       echo "Skipping $LIB"
+      # linux-vdso.so.1 is not a normal file
     ;;
     *)
       echo $LIB

--- a/copylibs.sh
+++ b/copylibs.sh
@@ -1,0 +1,15 @@
+#/bin/bash
+set -e
+
+ldd /bin/clamscan /bin/freshclam /bin/ld | grep so | sed -e '/^[^\t]/ d' | sed -e 's/\t//' | sed -e 's/.*=..//' | sed -e 's/ (0.*)//' | sort | uniq | while read LIB;
+do
+  case $LIB in
+    "linux-vdso.so.1")
+      echo "Skipping $LIB"
+    ;;
+    *)
+      echo $LIB
+      cp $LIB /opt/app/bin
+    ;;
+  esac
+done

--- a/scan.py
+++ b/scan.py
@@ -41,17 +41,18 @@ from common import S3_ENDPOINT
 from common import create_dir
 from common import get_timestamp
 
+
 # https://github.com/python/cpython/blob/v3.11.2/Lib/distutils/util.py#L308
-def strtobool (val):
+def strtobool(val):
     """Convert a string representation of truth to true (1) or false (0).
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
     are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
     'val' is anything else.
     """
     val = val.lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+    if val in ("y", "yes", "t", "true", "on", "1"):
         return 1
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    elif val in ("n", "no", "f", "false", "off", "0"):
         return 0
     else:
         raise ValueError("invalid truth value %r" % (val,))

--- a/scan.py
+++ b/scan.py
@@ -17,7 +17,6 @@ import copy
 import json
 import os
 from urllib.parse import unquote_plus
-from distutils.util import strtobool
 
 import boto3
 
@@ -41,6 +40,21 @@ from common import SNS_ENDPOINT
 from common import S3_ENDPOINT
 from common import create_dir
 from common import get_timestamp
+
+# https://github.com/python/cpython/blob/v3.11.2/Lib/distutils/util.py#L308
+def strtobool (val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 def event_object(event, event_source="s3"):

--- a/scan_bucket_test.py
+++ b/scan_bucket_test.py
@@ -125,4 +125,4 @@ class TestDisplayInfected(unittest.TestCase):
                 }
             ]
         }
-        self.assertEquals(s3_event, expected_s3_event)
+        self.assertEqual(s3_event, expected_s3_event)

--- a/scan_test.py
+++ b/scan_test.py
@@ -64,7 +64,7 @@ class TestScan(unittest.TestCase):
         sns_event = {"Records": [{"Sns": {"Message": json.dumps(event)}}]}
         s3_obj = event_object(sns_event, event_source="sns")
         expected_s3_object = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
-        self.assertEquals(s3_obj, expected_s3_object)
+        self.assertEqual(s3_obj, expected_s3_object)
 
     def test_s3_event_object(self):
         event = {
@@ -79,25 +79,25 @@ class TestScan(unittest.TestCase):
         }
         s3_obj = event_object(event)
         expected_s3_object = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
-        self.assertEquals(s3_obj, expected_s3_object)
+        self.assertEqual(s3_obj, expected_s3_object)
 
     def test_s3_event_object_missing_bucket(self):
         event = {"Records": [{"s3": {"object": {"key": self.s3_key_name}}}]}
         with self.assertRaises(Exception) as cm:
             event_object(event)
-            self.assertEquals(cm.exception.message, "No bucket found in event!")
+            self.assertEqual(cm.exception.message, "No bucket found in event!")
 
     def test_s3_event_object_missing_key(self):
         event = {"Records": [{"s3": {"bucket": {"name": self.s3_bucket_name}}}]}
         with self.assertRaises(Exception) as cm:
             event_object(event)
-            self.assertEquals(cm.exception.message, "No key found in event!")
+            self.assertEqual(cm.exception.message, "No key found in event!")
 
     def test_s3_event_object_bucket_key_missing(self):
         event = {"Records": [{"s3": {"bucket": {}, "object": {}}}]}
         with self.assertRaises(Exception) as cm:
             event_object(event)
-            self.assertEquals(
+            self.assertEqual(
                 cm.exception.message,
                 "Unable to retrieve object from event.\n{}".format(event),
             )
@@ -106,7 +106,7 @@ class TestScan(unittest.TestCase):
         event = {"Records": []}
         with self.assertRaises(Exception) as cm:
             event_object(event)
-            self.assertEquals(cm.exception.message, "No records found in event!")
+            self.assertEqual(cm.exception.message, "No records found in event!")
 
     def test_verify_s3_object_version(self):
         s3_obj = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
@@ -165,7 +165,7 @@ class TestScan(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             with s3_stubber_resource:
                 verify_s3_object_version(self.s3, s3_obj)
-            self.assertEquals(
+            self.assertEqual(
                 cm.exception.message,
                 "Object versioning is not enabled in bucket {}".format(
                     self.s3_bucket_name
@@ -220,7 +220,7 @@ class TestScan(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             with s3_stubber_resource:
                 verify_s3_object_version(self.s3, s3_obj)
-            self.assertEquals(
+            self.assertEqual(
                 cm.exception.message,
                 "Detected multiple object versions in {}.{}, aborting processing".format(
                     self.s3_bucket_name, self.s3_key_name
@@ -267,7 +267,7 @@ class TestScan(unittest.TestCase):
         s3_obj = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
         file_path = get_local_path(s3_obj, local_prefix)
         expected_file_path = "/tmp/test_bucket/test_key"
-        self.assertEquals(file_path, expected_file_path)
+        self.assertEqual(file_path, expected_file_path)
 
     def test_set_av_metadata(self):
         scan_result = "CLEAN"
@@ -424,7 +424,7 @@ class TestScan(unittest.TestCase):
             with s3_stubber:
                 s3_obj = self.s3.Object(self.s3_bucket_name, self.s3_key_name)
                 delete_s3_object(s3_obj)
-            self.assertEquals(
+            self.assertEqual(
                 cm.exception.message,
                 "Failed to delete infected file: {}.{}".format(
                     self.s3_bucket_name, self.s3_key_name


### PR DESCRIPTION
 - Change source image to amazon linux 2023
 - Simplify Dockerfile
 - Ensure we always copy the full set of linked libs required to run clam even if those change over time
 - Test vs python3.12 as this is what the lambda will run (3.11 is the newest in the repo)
 - Fixes for removed `assertEquals` and `strtobool`